### PR TITLE
Fixing CI failures with Ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fluent-plugin-kafka.gemspec
 gemspec
-
-if ENV['USE_RDKAFKA']
-  gem 'rdkafka', ENV['RDKAFKA_VERSION_MIN_RANGE'], ENV['RDKAFKA_VERSION_MAX_RANGE']
-  min_version = Gem::Version.new('0.16.0')
-  min_range_version = Gem::Version.new(ENV['RDKAFKA_VERSION_MIN_RANGE'].split(' ').last)
-  if min_range_version >= min_version
-    gem 'aws-msk-iam-sasl-signer'
-    gem 'json', '2.7.3' # override of 2.7.4 version
-  end
-end

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,12 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in fluent-plugin-kafka.gemspec
 gemspec
 
-gem 'json', '2.7.3' # override of 2.7.4 version
-gem 'rdkafka', ENV['RDKAFKA_VERSION_MIN_RANGE'], ENV['RDKAFKA_VERSION_MAX_RANGE'] if ENV['USE_RDKAFKA']
+if ENV['USE_RDKAFKA']
+  gem 'rdkafka', ENV['RDKAFKA_VERSION_MIN_RANGE'], ENV['RDKAFKA_VERSION_MAX_RANGE']
+  min_version = Gem::Version.new('0.16.0')
+  min_range_version = Gem::Version.new(ENV['RDKAFKA_VERSION_MIN_RANGE'].split(' ').last)
+  if min_range_version >= min_version
+    gem 'aws-msk-iam-sasl-signer'
+    gem 'json', '2.7.3' # override of 2.7.4 version
+  end
+end

--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   if ENV['USE_RDKAFKA']
     gem.add_dependency 'rdkafka', [ENV['RDKAFKA_VERSION_MIN_RANGE'], ENV['RDKAFKA_VERSION_MAX_RANGE']]
-    if Gem::Version.new('3.0') >= Gem::Version.new(RUBY_VERSION)
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
       gem.add_dependency 'aws-msk-iam-sasl-signer', '~> 0.1.1'
     end
   end

--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
   gem.add_dependency 'ltsv'
   gem.add_dependency 'ruby-kafka', '>= 1.5.0', '< 2'
-  gem.add_dependency 'rdkafka'
-  gem.add_dependency 'aws-msk-iam-sasl-signer'
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.0.8"
   gem.add_development_dependency "test-unit-rr", "~> 1.0"

--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   if ENV['USE_RDKAFKA']
     gem.add_dependency 'rdkafka', [ENV['RDKAFKA_VERSION_MIN_RANGE'], ENV['RDKAFKA_VERSION_MAX_RANGE']]
-    if Gem::Version.new('3.0' >= Gem::Version.new(RUBY_VERSION)
+    if Gem::Version.new('3.0') >= Gem::Version.new(RUBY_VERSION)
       gem.add_dependency 'aws-msk-iam-sasl-signer', '~> 0.1.1'
     end
   end

--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -19,6 +19,12 @@ Gem::Specification.new do |gem|
   gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
   gem.add_dependency 'ltsv'
   gem.add_dependency 'ruby-kafka', '>= 1.5.0', '< 2'
+
+  if ENV['USE_RDKAFKA']
+    gem.add_dependency 'rdkafka', [ENV['RDKAFKA_VERSION_MIN_RANGE'], ENV['RDKAFKA_VERSION_MAX_RANGE']]
+    gem.add_dependency 'aws-msk-iam-sasl-signer', '~> 0.1.1'
+  end
+
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.0.8"
   gem.add_development_dependency "test-unit-rr", "~> 1.0"

--- a/fluent-plugin-kafka.gemspec
+++ b/fluent-plugin-kafka.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |gem|
 
   if ENV['USE_RDKAFKA']
     gem.add_dependency 'rdkafka', [ENV['RDKAFKA_VERSION_MIN_RANGE'], ENV['RDKAFKA_VERSION_MAX_RANGE']]
-    gem.add_dependency 'aws-msk-iam-sasl-signer', '~> 0.1.1'
+    if Gem::Version.new('3.0' >= Gem::Version.new(RUBY_VERSION)
+      gem.add_dependency 'aws-msk-iam-sasl-signer', '~> 0.1.1'
+    end
   end
 
   gem.add_development_dependency "rake", ">= 0.9.2"

--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -4,7 +4,6 @@ require 'fluent/plugin/output'
 require 'fluent/plugin/kafka_plugin_util'
 
 require 'rdkafka'
-require 'aws_msk_iam_sasl_signer'
 
 begin
   rdkafka_version = Gem::Version::create(Rdkafka::VERSION)
@@ -16,6 +15,7 @@ begin
     require_relative 'rdkafka_patch/0_14_0'
   elsif rdkafka_version >= Gem::Version.create('0.16.0')
     require_relative 'rdkafka_patch/0_16_0'
+    require 'aws_msk_iam_sasl_signer'
   end
 rescue LoadError, NameError
   raise "unable to patch rdkafka."
@@ -208,7 +208,6 @@ DESC
           end
         end
       }
-      # HERE -----------------
       Rdkafka::Config.logger = log
       config = build_config
       @rdkafka = Rdkafka::Config.new(config)
@@ -217,7 +216,6 @@ DESC
       if config[:"security.protocol"] == "sasl_ssl" && config[:"sasl.mechanisms"] == "OAUTHBEARER"
         Rdkafka::Config.oauthbearer_token_refresh_callback = method(:refresh_token)
       end
-      # HERE -----------------
 
       if @default_topic.nil?
         if @use_default_for_unknown_topic || @use_default_for_unknown_partition_error

--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -16,9 +16,12 @@ begin
   elsif rdkafka_version >= Gem::Version.create('0.16.0')
     require_relative 'rdkafka_patch/0_16_0'
   end
-  require 'aws_msk_iam_sasl_signer' if rdkafka_version >= Gem::Version.create('0.16.0')
 rescue LoadError, NameError
   raise "unable to patch rdkafka."
+end
+
+if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('3.0')
+  require 'aws-msk-iam-sasl-signer'
 end
 
 module Fluent::Plugin

--- a/lib/fluent/plugin/out_rdkafka2.rb
+++ b/lib/fluent/plugin/out_rdkafka2.rb
@@ -15,8 +15,8 @@ begin
     require_relative 'rdkafka_patch/0_14_0'
   elsif rdkafka_version >= Gem::Version.create('0.16.0')
     require_relative 'rdkafka_patch/0_16_0'
-    require 'aws_msk_iam_sasl_signer'
   end
+  require 'aws_msk_iam_sasl_signer' if rdkafka_version >= Gem::Version.create('0.16.0')
 rescue LoadError, NameError
   raise "unable to patch rdkafka."
 end


### PR DESCRIPTION
The GHA CI pipelines tests the code with Ruby 2.7 and some versions of the `rdkafka` gem that still support that Ruby version. The newly introduced `aws-msk-iam-sasl-signer` gem requires at a minimum Ruby 3.0 so those tests are failing. I am now adding that dependency and also the rdkafka conditionally.